### PR TITLE
Update deprecated babel dep

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -53,7 +53,7 @@ function compile(code, options, cb) {
 
     if (use_latest) {
         try {
-            code = require('babel').transform(code, { ast: false, loose: 'all' }).code;
+            code = require('babel-core').transform(code, { ast: false, presets:[ ["env", {"loose": true}] ] }).code;
         } catch (e) {
             const error = new Error(`Failed to compile code with "use latest" directive: ${e.toString()}`);
 

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -53,7 +53,7 @@ function compile(code, options, cb) {
 
     if (use_latest) {
         try {
-            code = require('babel-core').transform(code, { ast: false, presets:[ ["env", {"loose": true}] ] }).code;
+            code = require('babel-core').transform(code, { ast: false, plugins: ["transform-object-rest-spread"], presets:[ ["env", {"loose": true}] ] }).code;
         } catch (e) {
             const error = new Error(`Failed to compile code with "use latest" directive: ${e.toString()}`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -374,6 +374,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
+    },
     "babel-plugin-syntax-trailing-function-commas": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
@@ -616,6 +621,15 @@
         "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
         "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+      "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webtask-runtime",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,52 +15,67 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       }
     },
     "ajv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "argparse": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-union": {
@@ -69,7 +84,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -84,2420 +99,767 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "async": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-      "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.17.10"
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
     },
-    "babel": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel/-/babel-5.8.38.tgz",
-      "integrity": "sha1-37CHwiiUkXxXb7Z86c8yjUWGKfs=",
-      "requires": {
-        "babel-core": "5.8.38",
-        "chokidar": "1.6.1",
-        "commander": "2.9.0",
-        "convert-source-map": "1.3.0",
-        "fs-readdir-recursive": "0.1.2",
-        "glob": "5.0.15",
-        "lodash": "3.10.1",
-        "output-file-sync": "1.1.2",
-        "path-exists": "1.0.0",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.6"
-      },
-      "dependencies": {
-        "babel-core": {
-          "version": "5.8.38",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
-          "integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
-          "requires": {
-            "babel-plugin-constant-folding": "1.0.1",
-            "babel-plugin-dead-code-elimination": "1.0.2",
-            "babel-plugin-eval": "1.0.1",
-            "babel-plugin-inline-environment-variables": "1.0.1",
-            "babel-plugin-jscript": "1.0.4",
-            "babel-plugin-member-expression-literals": "1.0.1",
-            "babel-plugin-property-literals": "1.0.1",
-            "babel-plugin-proto-to-assign": "1.0.4",
-            "babel-plugin-react-constant-elements": "1.0.3",
-            "babel-plugin-react-display-name": "1.0.3",
-            "babel-plugin-remove-console": "1.0.1",
-            "babel-plugin-remove-debugger": "1.0.1",
-            "babel-plugin-runtime": "1.0.7",
-            "babel-plugin-undeclared-variables-check": "1.0.2",
-            "babel-plugin-undefined-to-void": "1.1.6",
-            "babylon": "5.8.38",
-            "bluebird": "2.11.0",
-            "chalk": "1.1.3",
-            "convert-source-map": "1.3.0",
-            "core-js": "1.2.7",
-            "debug": "2.6.0",
-            "detect-indent": "3.0.1",
-            "esutils": "2.0.2",
-            "fs-readdir-recursive": "0.1.2",
-            "globals": "6.4.1",
-            "home-or-tmp": "1.0.0",
-            "is-integer": "1.0.6",
-            "js-tokens": "1.0.1",
-            "json5": "0.4.0",
-            "lodash": "3.10.1",
-            "minimatch": "2.0.10",
-            "output-file-sync": "1.1.2",
-            "path-exists": "1.0.0",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.6",
-            "regenerator": "0.8.40",
-            "regexpu": "1.3.0",
-            "repeating": "1.1.3",
-            "resolve": "1.2.0",
-            "shebang-regex": "1.0.0",
-            "slash": "1.0.0",
-            "source-map": "0.5.6",
-            "source-map-support": "0.2.10",
-            "to-fast-properties": "1.0.2",
-            "trim-right": "1.0.1",
-            "try-resolve": "1.0.1"
-          },
-          "dependencies": {
-            "babel-plugin-constant-folding": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
-              "integrity": "sha1-g2HTZMmORJw2kr26Ue/whEKQqo4="
-            },
-            "babel-plugin-dead-code-elimination": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
-              "integrity": "sha1-X3xFEnTc18zNv7s+C4XdKBIfD2U="
-            },
-            "babel-plugin-eval": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
-              "integrity": "sha1-ovrtJc5r5preS/7CY/cBaRlZUNo="
-            },
-            "babel-plugin-inline-environment-variables": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
-              "integrity": "sha1-H1jOkSB61qgmqL9kX6/mj/X+P/4="
-            },
-            "babel-plugin-jscript": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
-              "integrity": "sha1-jzQsOCduh6R9X6CovT1etsytj8w="
-            },
-            "babel-plugin-member-expression-literals": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
-              "integrity": "sha1-zF7bD6qNyScXDnTW0cAkQAIWJNM="
-            },
-            "babel-plugin-property-literals": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
-              "integrity": "sha1-AlIwGQAZKYCxwRjv6kjOk6q4MzY="
-            },
-            "babel-plugin-proto-to-assign": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
-              "integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
-              "requires": {
-                "lodash": "3.10.1"
-              }
-            },
-            "babel-plugin-react-constant-elements": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
-              "integrity": "sha1-lGc26DeEKcvDSdz/YvUcFDs041o="
-            },
-            "babel-plugin-react-display-name": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
-              "integrity": "sha1-dU/jiSboQkpOexWrbqYTne4FFPw="
-            },
-            "babel-plugin-remove-console": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
-              "integrity": "sha1-2PJFVsOgUAXUKqqv0neH9T/wE6c="
-            },
-            "babel-plugin-remove-debugger": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
-              "integrity": "sha1-/S6jzWGkKK0fO5yJiC/0KT6MFMc="
-            },
-            "babel-plugin-runtime": {
-              "version": "1.0.7",
-              "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
-              "integrity": "sha1-v3x9lm3Vbs1cF/ocslPJrLflSq8="
-            },
-            "babel-plugin-undeclared-variables-check": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
-              "integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
-              "requires": {
-                "leven": "1.0.2"
-              },
-              "dependencies": {
-                "leven": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
-                  "integrity": "sha1-kUS27ryl8dBoAWnxpncNzqYLdcM="
-                }
-              }
-            },
-            "babel-plugin-undefined-to-void": {
-              "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
-              "integrity": "sha1-f1eO+LeN+uYAM4XYQXph7aBuL4E="
-            },
-            "babylon": {
-              "version": "5.8.38",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.38.tgz",
-              "integrity": "sha1-7JsSCxG/bM1Bc6GL8hfmC3mFn/0="
-            },
-            "bluebird": {
-              "version": "2.11.0",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-              "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-                }
-              }
-            },
-            "core-js": {
-              "version": "1.2.7",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-              "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-            },
-            "debug": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-              "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-              "requires": {
-                "ms": "0.7.2"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                  "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-                }
-              }
-            },
-            "detect-indent": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-              "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
-              "requires": {
-                "get-stdin": "4.0.1",
-                "minimist": "1.2.0",
-                "repeating": "1.1.3"
-              },
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                  "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-                }
-              }
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
-            },
-            "globals": {
-              "version": "6.4.1",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
-              "integrity": "sha1-hJgDKzttHMge68X3lpDY/in6v08="
-            },
-            "home-or-tmp": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-              "integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
-              "requires": {
-                "os-tmpdir": "1.0.2",
-                "user-home": "1.1.1"
-              },
-              "dependencies": {
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-                },
-                "user-home": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-                  "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
-                }
-              }
-            },
-            "is-integer": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-              "integrity": "sha1-UnOBn62ogNEj4awAqTjnFy3Y2V4=",
-              "requires": {
-                "is-finite": "1.0.2"
-              },
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                  "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-                    }
-                  }
-                }
-              }
-            },
-            "js-tokens": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
-              "integrity": "sha1-zENaXIuUrRWst5gxQPyAGCyJrq4="
-            },
-            "json5": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-              "integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-              "requires": {
-                "brace-expansion": "1.1.6"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.6",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                  "requires": {
-                    "balanced-match": "0.4.2",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                    }
-                  }
-                }
-              }
-            },
-            "private": {
-              "version": "0.1.6",
-              "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
-              "integrity": "sha1-VcapdtD5uvuZJIUTUP5HubX7t8E="
-            },
-            "regenerator": {
-              "version": "0.8.40",
-              "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-              "integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
-              "requires": {
-                "commoner": "0.10.8",
-                "defs": "1.1.1",
-                "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                "private": "0.1.6",
-                "recast": "0.10.33",
-                "through": "2.3.8"
-              },
-              "dependencies": {
-                "commoner": {
-                  "version": "0.10.8",
-                  "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-                  "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-                  "requires": {
-                    "commander": "2.9.0",
-                    "detective": "4.3.2",
-                    "glob": "5.0.15",
-                    "graceful-fs": "4.1.11",
-                    "iconv-lite": "0.4.15",
-                    "mkdirp": "0.5.1",
-                    "private": "0.1.6",
-                    "q": "1.4.1",
-                    "recast": "0.11.18"
-                  },
-                  "dependencies": {
-                    "detective": {
-                      "version": "4.3.2",
-                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz",
-                      "integrity": "sha1-d2l+LnlHrD/nyOJqbW8RUjWvqRw=",
-                      "requires": {
-                        "acorn": "3.3.0",
-                        "defined": "1.0.0"
-                      },
-                      "dependencies": {
-                        "defined": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-                          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-                    },
-                    "iconv-lite": {
-                      "version": "0.4.15",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-                      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                      "requires": {
-                        "minimist": "0.0.8"
-                      },
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                        }
-                      }
-                    },
-                    "q": {
-                      "version": "1.4.1",
-                      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
-                    },
-                    "recast": {
-                      "version": "0.11.18",
-                      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.18.tgz",
-                      "integrity": "sha1-B69iV8p2mGiBUglAHU1g7vG1uUc=",
-                      "requires": {
-                        "ast-types": "0.9.2",
-                        "esprima": "3.1.3",
-                        "private": "0.1.6",
-                        "source-map": "0.5.6"
-                      },
-                      "dependencies": {
-                        "ast-types": {
-                          "version": "0.9.2",
-                          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz",
-                          "integrity": "sha1-LMGZedFcZVEIv1ZTI7jn7jh1H2s="
-                        },
-                        "esprima": {
-                          "version": "3.1.3",
-                          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-                          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-                        }
-                      }
-                    }
-                  }
-                },
-                "defs": {
-                  "version": "1.1.1",
-                  "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-                  "integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
-                  "requires": {
-                    "alter": "0.2.0",
-                    "ast-traverse": "0.1.1",
-                    "breakable": "1.0.0",
-                    "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                    "simple-fmt": "0.1.0",
-                    "simple-is": "0.2.0",
-                    "stringmap": "0.2.2",
-                    "stringset": "0.2.1",
-                    "tryor": "0.1.2",
-                    "yargs": "3.27.0"
-                  },
-                  "dependencies": {
-                    "alter": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-                      "integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
-                      "requires": {
-                        "stable": "0.1.5"
-                      },
-                      "dependencies": {
-                        "stable": {
-                          "version": "0.1.5",
-                          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
-                          "integrity": "sha1-CCMvYMcy6YkHhLW+0HNPizKoh7k="
-                        }
-                      }
-                    },
-                    "ast-traverse": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
-                      "integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY="
-                    },
-                    "breakable": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
-                      "integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME="
-                    },
-                    "simple-fmt": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
-                      "integrity": "sha1-GRv1ZqWeZTBILLJatTtKjchcOms="
-                    },
-                    "simple-is": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
-                      "integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA="
-                    },
-                    "stringmap": {
-                      "version": "0.2.2",
-                      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
-                      "integrity": "sha1-VWwTeyWPlCuHdvWy71gqoGnX0bE="
-                    },
-                    "stringset": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
-                      "integrity": "sha1-7yWcTjSTRDd/zRyRPdLoSMnAQrU="
-                    },
-                    "tryor": {
-                      "version": "0.1.2",
-                      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
-                      "integrity": "sha1-gUXkynyv9ArN48z5Rui4u3W0Fys="
-                    },
-                    "yargs": {
-                      "version": "3.27.0",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-                      "integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
-                      "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "os-locale": "1.4.0",
-                        "window-size": "0.1.4",
-                        "y18n": "3.2.1"
-                      },
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
-                        },
-                        "cliui": {
-                          "version": "2.1.0",
-                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                          "requires": {
-                            "center-align": "0.1.3",
-                            "right-align": "0.1.3",
-                            "wordwrap": "0.0.2"
-                          },
-                          "dependencies": {
-                            "center-align": {
-                              "version": "0.1.3",
-                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-                              "requires": {
-                                "align-text": "0.1.4",
-                                "lazy-cache": "1.0.4"
-                              },
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                                  "requires": {
-                                    "kind-of": "3.1.0",
-                                    "longest": "1.0.1",
-                                    "repeat-string": "1.6.1"
-                                  },
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.1.0",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                                      "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-                                      "requires": {
-                                        "is-buffer": "1.1.4"
-                                      },
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.4",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-                                          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.6.1",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-                                    }
-                                  }
-                                },
-                                "lazy-cache": {
-                                  "version": "1.0.4",
-                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                                  "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-                                }
-                              }
-                            },
-                            "right-align": {
-                              "version": "0.1.3",
-                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-                              "requires": {
-                                "align-text": "0.1.4"
-                              },
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.4",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                                  "requires": {
-                                    "kind-of": "3.1.0",
-                                    "longest": "1.0.1",
-                                    "repeat-string": "1.6.1"
-                                  },
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.1.0",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                                      "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-                                      "requires": {
-                                        "is-buffer": "1.1.4"
-                                      },
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.4",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-                                          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.6.1",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "wordwrap": {
-                              "version": "0.0.2",
-                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.2.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-                        },
-                        "os-locale": {
-                          "version": "1.4.0",
-                          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-                          "requires": {
-                            "lcid": "1.0.0"
-                          },
-                          "dependencies": {
-                            "lcid": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                              "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-                              "requires": {
-                                "invert-kv": "1.0.0"
-                              },
-                              "dependencies": {
-                                "invert-kv": {
-                                  "version": "1.0.0",
-                                  "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-                                  "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "window-size": {
-                          "version": "0.1.4",
-                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-                          "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
-                        },
-                        "y18n": {
-                          "version": "3.2.1",
-                          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-                        }
-                      }
-                    }
-                  }
-                },
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-                  "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
-                },
-                "recast": {
-                  "version": "0.10.33",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-                  "integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
-                  "requires": {
-                    "ast-types": "0.8.12",
-                    "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                    "private": "0.1.6",
-                    "source-map": "0.5.6"
-                  },
-                  "dependencies": {
-                    "ast-types": {
-                      "version": "0.8.12",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
-                      "integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w="
-                    }
-                  }
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-                }
-              }
-            },
-            "regexpu": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-              "integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
-              "requires": {
-                "esprima": "2.7.3",
-                "recast": "0.10.43",
-                "regenerate": "1.3.2",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
-              },
-              "dependencies": {
-                "esprima": {
-                  "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                  "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-                },
-                "recast": {
-                  "version": "0.10.43",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
-                  "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
-                  "requires": {
-                    "ast-types": "0.8.15",
-                    "esprima-fb": "15001.1001.0-dev-harmony-fb",
-                    "private": "0.1.6",
-                    "source-map": "0.5.6"
-                  },
-                  "dependencies": {
-                    "ast-types": {
-                      "version": "0.8.15",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
-                      "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI="
-                    },
-                    "esprima-fb": {
-                      "version": "15001.1001.0-dev-harmony-fb",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-                      "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
-                    }
-                  }
-                },
-                "regenerate": {
-                  "version": "1.3.2",
-                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-                  "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
-                },
-                "regjsgen": {
-                  "version": "0.2.0",
-                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-                  "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-                },
-                "regjsparser": {
-                  "version": "0.1.5",
-                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                  "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-                  "requires": {
-                    "jsesc": "0.5.0"
-                  },
-                  "dependencies": {
-                    "jsesc": {
-                      "version": "0.5.0",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-                      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-                    }
-                  }
-                }
-              }
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-              "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
-              "requires": {
-                "is-finite": "1.0.2"
-              },
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                  "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-                  "requires": {
-                    "number-is-nan": "1.0.1"
-                  },
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-                    }
-                  }
-                }
-              }
-            },
-            "resolve": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
-              "integrity": "sha1-lYnD8vYUnRQXpAvswWY9tuxrwmw="
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-              "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-            },
-            "source-map-support": {
-              "version": "0.2.10",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-              "integrity": "sha1-6lo5AKHByyUJagrozFwrSxDe09w=",
-              "requires": {
-                "source-map": "0.1.32"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.32",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                  "integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
-                  "requires": {
-                    "amdefine": "1.0.1"
-                  },
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-                    }
-                  }
-                }
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-              "integrity": "sha1-8/XAw7pymafvmUJ+RGMyV63kMyA="
-            },
-            "trim-right": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-              "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-            },
-            "try-resolve": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
-              "integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI="
-            }
-          }
-        },
-        "chokidar": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
-          "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
-          "requires": {
-            "anymatch": "1.3.0",
-            "async-each": "1.0.1",
-            "fsevents": "1.0.17",
-            "glob-parent": "2.0.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "2.0.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.1.0"
-          },
-          "dependencies": {
-            "anymatch": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-              "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-              "requires": {
-                "arrify": "1.0.1",
-                "micromatch": "2.3.11"
-              },
-              "dependencies": {
-                "arrify": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                  "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-                },
-                "micromatch": {
-                  "version": "2.3.11",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                  "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-                  "requires": {
-                    "arr-diff": "2.0.0",
-                    "array-unique": "0.2.1",
-                    "braces": "1.8.5",
-                    "expand-brackets": "0.1.5",
-                    "extglob": "0.3.2",
-                    "filename-regex": "2.0.0",
-                    "is-extglob": "1.0.0",
-                    "is-glob": "2.0.1",
-                    "kind-of": "3.1.0",
-                    "normalize-path": "2.0.1",
-                    "object.omit": "2.0.1",
-                    "parse-glob": "3.0.4",
-                    "regex-cache": "0.4.3"
-                  },
-                  "dependencies": {
-                    "arr-diff": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                      "requires": {
-                        "arr-flatten": "1.0.1"
-                      },
-                      "dependencies": {
-                        "arr-flatten": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-                          "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs="
-                        }
-                      }
-                    },
-                    "array-unique": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-                    },
-                    "braces": {
-                      "version": "1.8.5",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-                      "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
-                      },
-                      "dependencies": {
-                        "expand-range": {
-                          "version": "1.8.2",
-                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-                          "requires": {
-                            "fill-range": "2.2.3"
-                          },
-                          "dependencies": {
-                            "fill-range": {
-                              "version": "2.2.3",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                              "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-                              "requires": {
-                                "is-number": "2.1.0",
-                                "isobject": "2.1.0",
-                                "randomatic": "1.1.6",
-                                "repeat-element": "1.1.2",
-                                "repeat-string": "1.6.1"
-                              },
-                              "dependencies": {
-                                "is-number": {
-                                  "version": "2.1.0",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                                  "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-                                  "requires": {
-                                    "kind-of": "3.1.0"
-                                  }
-                                },
-                                "isobject": {
-                                  "version": "2.1.0",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                                  "requires": {
-                                    "isarray": "1.0.0"
-                                  },
-                                  "dependencies": {
-                                    "isarray": {
-                                      "version": "1.0.0",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                                    }
-                                  }
-                                },
-                                "randomatic": {
-                                  "version": "1.1.6",
-                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-                                  "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-                                  "requires": {
-                                    "is-number": "2.1.0",
-                                    "kind-of": "3.1.0"
-                                  }
-                                },
-                                "repeat-string": {
-                                  "version": "1.6.1",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                  "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "preserve": {
-                          "version": "0.2.0",
-                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-                        },
-                        "repeat-element": {
-                          "version": "1.1.2",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-                        }
-                      }
-                    },
-                    "expand-brackets": {
-                      "version": "0.1.5",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-                      "requires": {
-                        "is-posix-bracket": "0.1.1"
-                      },
-                      "dependencies": {
-                        "is-posix-bracket": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-                          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-                        }
-                      }
-                    },
-                    "extglob": {
-                      "version": "0.3.2",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-                      "requires": {
-                        "is-extglob": "1.0.0"
-                      }
-                    },
-                    "filename-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                      "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U="
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                    },
-                    "kind-of": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                      "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-                      "requires": {
-                        "is-buffer": "1.1.4"
-                      },
-                      "dependencies": {
-                        "is-buffer": {
-                          "version": "1.1.4",
-                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-                          "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
-                        }
-                      }
-                    },
-                    "normalize-path": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-                      "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o="
-                    },
-                    "object.omit": {
-                      "version": "2.0.1",
-                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-                      "requires": {
-                        "for-own": "0.1.4",
-                        "is-extendable": "0.1.1"
-                      },
-                      "dependencies": {
-                        "for-own": {
-                          "version": "0.1.4",
-                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-                          "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
-                          "requires": {
-                            "for-in": "0.1.6"
-                          },
-                          "dependencies": {
-                            "for-in": {
-                              "version": "0.1.6",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-                              "integrity": "sha1-yfluib+tGKVFr17D7TUqHZ5bTcg="
-                            }
-                          }
-                        },
-                        "is-extendable": {
-                          "version": "0.1.1",
-                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-                        }
-                      }
-                    },
-                    "parse-glob": {
-                      "version": "3.0.4",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-                      "requires": {
-                        "glob-base": "0.3.0",
-                        "is-dotfile": "1.0.2",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1"
-                      },
-                      "dependencies": {
-                        "glob-base": {
-                          "version": "0.3.0",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-                          "requires": {
-                            "glob-parent": "2.0.0",
-                            "is-glob": "2.0.1"
-                          }
-                        },
-                        "is-dotfile": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                          "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0="
-                        }
-                      }
-                    },
-                    "regex-cache": {
-                      "version": "0.4.3",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-                      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-                      "requires": {
-                        "is-equal-shallow": "0.1.3",
-                        "is-primitive": "2.0.0"
-                      },
-                      "dependencies": {
-                        "is-equal-shallow": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-                          "requires": {
-                            "is-primitive": "2.0.0"
-                          }
-                        },
-                        "is-primitive": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "async-each": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-              "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
-            },
-            "fsevents": {
-              "version": "1.0.17",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.17.tgz",
-              "integrity": "sha1-hTfz8SJyZ4dltP1lKMDx9m+PRVg=",
-              "optional": true,
-              "requires": {
-                "nan": "2.5.0",
-                "node-pre-gyp": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz"
-              },
-              "dependencies": {
-                "abbrev": {
-                  "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                  "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
-                  "optional": true
-                },
-                "ansi-regex": {
-                  "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
-                },
-                "ansi-styles": {
-                  "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                  "optional": true
-                },
-                "aproba": {
-                  "version": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-                  "integrity": "sha1-JxNoB3XnYUyLoYbAZdTi5S0QcsA=",
-                  "optional": true
-                },
-                "are-we-there-yet": {
-                  "version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-                  "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
-                  "optional": true,
-                  "requires": {
-                    "delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                    "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
-                  }
-                },
-                "asn1": {
-                  "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                  "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                  "optional": true
-                },
-                "assert-plus": {
-                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                  "optional": true
-                },
-                "asynckit": {
-                  "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-                  "optional": true
-                },
-                "aws-sign2": {
-                  "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                  "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-                  "optional": true
-                },
-                "aws4": {
-                  "version": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
-                  "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
-                  "optional": true
-                },
-                "balanced-match": {
-                  "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-                },
-                "bcrypt-pbkdf": {
-                  "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                  "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
-                  "optional": true,
-                  "requires": {
-                    "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                  }
-                },
-                "block-stream": {
-                  "version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                  "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-                  "requires": {
-                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                  }
-                },
-                "boom": {
-                  "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                  "requires": {
-                    "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                  }
-                },
-                "brace-expansion": {
-                  "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                  "requires": {
-                    "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                    "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                  }
-                },
-                "buffer-shims": {
-                  "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                  "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-                },
-                "caseless": {
-                  "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                  "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-                  "optional": true
-                },
-                "chalk": {
-                  "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                  "optional": true,
-                  "requires": {
-                    "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                    "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                  },
-                  "dependencies": {
-                    "supports-color": {
-                      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                      "optional": true
-                    }
-                  }
-                },
-                "code-point-at": {
-                  "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-                },
-                "combined-stream": {
-                  "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                  "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-                  "requires": {
-                    "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                  }
-                },
-                "commander": {
-                  "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                  "optional": true,
-                  "requires": {
-                    "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                  }
-                },
-                "concat-map": {
-                  "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                },
-                "console-control-strings": {
-                  "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                  "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-                },
-                "core-util-is": {
-                  "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                },
-                "cryptiles": {
-                  "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                  "optional": true,
-                  "requires": {
-                    "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                  }
-                },
-                "dashdash": {
-                  "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                  "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                  "optional": true,
-                  "requires": {
-                    "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                      "optional": true
-                    }
-                  }
-                },
-                "debug": {
-                  "version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                  "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-                  "optional": true,
-                  "requires": {
-                    "ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                  }
-                },
-                "deep-extend": {
-                  "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                  "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-                  "optional": true
-                },
-                "delayed-stream": {
-                  "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-                },
-                "delegates": {
-                  "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-                  "optional": true
-                },
-                "ecc-jsbn": {
-                  "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                  "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                  "optional": true,
-                  "requires": {
-                    "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                  }
-                },
-                "escape-string-regexp": {
-                  "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                  "optional": true
-                },
-                "extend": {
-                  "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                  "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-                  "optional": true
-                },
-                "extsprintf": {
-                  "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                  "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
-                },
-                "forever-agent": {
-                  "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                  "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-                  "optional": true
-                },
-                "form-data": {
-                  "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-                  "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-                  "optional": true,
-                  "requires": {
-                    "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                    "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                    "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz"
-                  }
-                },
-                "fs.realpath": {
-                  "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-                },
-                "fstream": {
-                  "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-                  "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-                  "requires": {
-                    "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                    "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
-                  }
-                },
-                "fstream-ignore": {
-                  "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                  "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-                  "optional": true,
-                  "requires": {
-                    "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
-                  }
-                },
-                "gauge": {
-                  "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
-                  "integrity": "sha1-Fc7MMbAtBTRaXWsOFxzbOtIwd3Q=",
-                  "optional": true,
-                  "requires": {
-                    "aproba": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-                    "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                    "has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                    "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                    "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                    "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-                    "wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
-                  }
-                },
-                "generate-function": {
-                  "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                  "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-                  "optional": true
-                },
-                "generate-object-property": {
-                  "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-                  "optional": true,
-                  "requires": {
-                    "is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                  }
-                },
-                "getpass": {
-                  "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                  "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-                  "optional": true,
-                  "requires": {
-                    "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                      "optional": true
-                    }
-                  }
-                },
-                "glob": {
-                  "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                  "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-                  "requires": {
-                    "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                    "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                    "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                    "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                  }
-                },
-                "graceful-fs": {
-                  "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-                },
-                "graceful-readlink": {
-                  "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                  "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-                  "optional": true
-                },
-                "har-validator": {
-                  "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                  "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-                  "optional": true,
-                  "requires": {
-                    "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                    "is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                    "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-                  }
-                },
-                "has-ansi": {
-                  "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                  "optional": true,
-                  "requires": {
-                    "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                  }
-                },
-                "has-unicode": {
-                  "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-                  "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-                  "optional": true
-                },
-                "hawk": {
-                  "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                  "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-                  "optional": true,
-                  "requires": {
-                    "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                    "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                    "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                    "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                  }
-                },
-                "hoek": {
-                  "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-                },
-                "http-signature": {
-                  "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                  "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                  "optional": true,
-                  "requires": {
-                    "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                    "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-                    "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz"
-                  }
-                },
-                "inflight": {
-                  "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                  "requires": {
-                    "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                    "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                  }
-                },
-                "inherits": {
-                  "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                },
-                "ini": {
-                  "version": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                  "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-                  "optional": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                  "requires": {
-                    "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                  "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-                  "optional": true,
-                  "requires": {
-                    "generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                    "generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                    "jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-                    "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                  }
-                },
-                "is-property": {
-                  "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                  "optional": true
-                },
-                "is-typedarray": {
-                  "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                  "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-                  "optional": true
-                },
-                "isarray": {
-                  "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                },
-                "isstream": {
-                  "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                  "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-                  "optional": true
-                },
-                "jodid25519": {
-                  "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                  "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-                  "optional": true,
-                  "requires": {
-                    "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-                  }
-                },
-                "jsbn": {
-                  "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                  "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
-                  "optional": true
-                },
-                "json-schema": {
-                  "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                  "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-                  "optional": true
-                },
-                "json-stringify-safe": {
-                  "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                  "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-                  "optional": true
-                },
-                "jsonpointer": {
-                  "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-                  "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-                  "optional": true
-                },
-                "jsprim": {
-                  "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-                  "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
-                  "optional": true,
-                  "requires": {
-                    "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                    "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                    "verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                  }
-                },
-                "mime-db": {
-                  "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
-                  "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
-                },
-                "mime-types": {
-                  "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-                  "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-                  "requires": {
-                    "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
-                  }
-                },
-                "minimatch": {
-                  "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                  "requires": {
-                    "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
-                  }
-                },
-                "minimist": {
-                  "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                },
-                "mkdirp": {
-                  "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-                  "requires": {
-                    "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                  }
-                },
-                "ms": {
-                  "version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                  "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-                  "optional": true
-                },
-                "nan": {
-                  "version": "2.5.0",
-                  "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.0.tgz",
-                  "integrity": "sha1-qo8eNFMdgH6eJ3VbI0tKbsDBUqg=",
-                  "optional": true
-                },
-                "node-pre-gyp": {
-                  "version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz",
-                  "integrity": "sha1-/EUrN25zGbPSVfXzSFPvb9j+H9U=",
-                  "optional": true,
-                  "requires": {
-                    "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                    "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                    "npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-                    "rc": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                    "request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                    "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                    "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                    "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-                    "tar-pack": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz"
-                  }
-                },
-                "nopt": {
-                  "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                  "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-                  "optional": true,
-                  "requires": {
-                    "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
-                  }
-                },
-                "npmlog": {
-                  "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-                  "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
-                  "optional": true,
-                  "requires": {
-                    "are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-                    "console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                    "gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
-                    "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-                  }
-                },
-                "number-is-nan": {
-                  "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-                },
-                "oauth-sign": {
-                  "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                  "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-                  "optional": true
-                },
-                "object-assign": {
-                  "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                  "optional": true
-                },
-                "once": {
-                  "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "requires": {
-                    "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-                },
-                "pinkie": {
-                  "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                  "optional": true
-                },
-                "pinkie-promise": {
-                  "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                  "optional": true,
-                  "requires": {
-                    "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                  }
-                },
-                "process-nextick-args": {
-                  "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-                },
-                "punycode": {
-                  "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                  "optional": true
-                },
-                "qs": {
-                  "version": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-                  "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
-                  "optional": true
-                },
-                "rc": {
-                  "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                  "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
-                  "optional": true,
-                  "requires": {
-                    "deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                    "ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-                    "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
-                  },
-                  "dependencies": {
-                    "minimist": {
-                      "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                      "optional": true
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                  "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-                  "optional": true,
-                  "requires": {
-                    "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                    "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                  }
-                },
-                "request": {
-                  "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                  "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                  "optional": true,
-                  "requires": {
-                    "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                    "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
-                    "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-                    "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                    "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-                    "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                    "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-                    "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-                    "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                    "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                    "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                    "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                    "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                    "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-                    "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                    "qs": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-                    "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                    "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                    "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                    "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-                  }
-                },
-                "rimraf": {
-                  "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                  "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-                  "requires": {
-                    "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
-                  }
-                },
-                "semver": {
-                  "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                  "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-                  "optional": true
-                },
-                "set-blocking": {
-                  "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                  "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-                  "optional": true
-                },
-                "signal-exit": {
-                  "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-                  "optional": true
-                },
-                "sntp": {
-                  "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                  "optional": true,
-                  "requires": {
-                    "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                  }
-                },
-                "sshpk": {
-                  "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
-                  "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
-                  "optional": true,
-                  "requires": {
-                    "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                    "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                    "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                    "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                    "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                    "jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                    "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                    "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                  },
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                      "optional": true
-                    }
-                  }
-                },
-                "string-width": {
-                  "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "requires": {
-                    "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                    "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                  }
-                },
-                "string_decoder": {
-                  "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                },
-                "stringstream": {
-                  "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                  "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-                  "optional": true
-                },
-                "strip-ansi": {
-                  "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "requires": {
-                    "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                  }
-                },
-                "strip-json-comments": {
-                  "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                  "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-                  "optional": true
-                },
-                "supports-color": {
-                  "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-                  "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-                  "optional": true
-                },
-                "tar": {
-                  "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-                  "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-                  "requires": {
-                    "block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-                    "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-                    "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                  }
-                },
-                "tar-pack": {
-                  "version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
-                  "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
-                  "optional": true,
-                  "requires": {
-                    "debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                    "fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-                    "fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-                    "once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                    "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                    "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                    "tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-                    "uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                  },
-                  "dependencies": {
-                    "once": {
-                      "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                      "optional": true,
-                      "requires": {
-                        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-                      "optional": true,
-                      "requires": {
-                        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                      }
-                    }
-                  }
-                },
-                "tough-cookie": {
-                  "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                  "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-                  "optional": true,
-                  "requires": {
-                    "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                  }
-                },
-                "tunnel-agent": {
-                  "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                  "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-                  "optional": true
-                },
-                "tweetnacl": {
-                  "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                  "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                  "optional": true
-                },
-                "uid-number": {
-                  "version": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-                  "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-                  "optional": true
-                },
-                "util-deprecate": {
-                  "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-                },
-                "uuid": {
-                  "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-                  "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-                  "optional": true
-                },
-                "verror": {
-                  "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                  "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                  "optional": true,
-                  "requires": {
-                    "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                  }
-                },
-                "wide-align": {
-                  "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-                  "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-                  "optional": true,
-                  "requires": {
-                    "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-                  }
-                },
-                "wrappy": {
-                  "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                },
-                "xtend": {
-                  "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-                  "optional": true
-                }
-              }
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-              "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-              "requires": {
-                "is-glob": "2.0.1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-              "requires": {
-                "binary-extensions": "1.8.0"
-              },
-              "dependencies": {
-                "binary-extensions": {
-                  "version": "1.8.0",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-                  "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q="
-                }
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-              "requires": {
-                "is-extglob": "1.0.0"
-              },
-              "dependencies": {
-                "is-extglob": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                  "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-                }
-              }
-            },
-            "readdirp": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-              "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.3",
-                "readable-stream": "2.2.2",
-                "set-immediate-shim": "1.0.1"
-              },
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.11",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-                },
-                "minimatch": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                  "requires": {
-                    "brace-expansion": "1.1.6"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                      "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.2.2",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                  "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-                  "requires": {
-                    "buffer-shims": "1.0.0",
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
-                  },
-                  "dependencies": {
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-                    }
-                  }
-                },
-                "set-immediate-shim": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-                  "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-                }
-              }
-            }
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          },
-          "dependencies": {
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-            }
-          }
-        },
-        "convert-source-map": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.3.0.tgz",
-          "integrity": "sha1-6fPpxuJyjvwmdmlqcOs4L3MQamc="
-        },
-        "fs-readdir-recursive": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
-          "integrity": "sha1-MVtPuMHKW4xH3v7zGdBz2tNWgFk="
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.3",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          },
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-              "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-            },
-            "minimatch": {
-              "version": "3.0.3",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-              "requires": {
-                "brace-expansion": "1.1.6"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.6",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                  "requires": {
-                    "balanced-match": "0.4.2",
-                    "concat-map": "0.0.1"
-                  },
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "requires": {
-                "wrappy": "1.0.2"
-              },
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-                }
-              }
-            }
-          }
-        },
-        "output-file-sync": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-          "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.0"
-          },
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.11",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "requires": {
-                "minimist": "0.0.8"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-              "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
-            }
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE="
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-        },
-        "slash": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
-        }
-      }
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
       },
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         }
       }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "requires": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "requires": {
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "requires": {
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "requires": {
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "requires": {
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "requires": {
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "requires": {
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "requires": {
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "requires": {
+        "regenerator-transform": "^0.10.0"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
-    "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "bossy": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/bossy/-/bossy-3.0.4.tgz",
+      "integrity": "sha1-+a6fJugbQaMY9O4Ng2huSlwlB7k=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "hoek": "4.x.x",
+        "joi": "10.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+          "dev": true
+        },
+        "isemail": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+          "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+          "dev": true
+        },
+        "joi": {
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+          "dev": true,
+          "requires": {
+            "hoek": "4.x.x",
+            "isemail": "2.x.x",
+            "items": "2.x.x",
+            "topo": "2.x.x"
+          }
+        },
+        "topo": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+          "dev": true,
+          "requires": {
+            "hoek": "4.x.x"
+          }
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
+    },
+    "browserslist": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "requires": {
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
+      }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -2505,7 +867,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -2514,36 +876,52 @@
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
-    "chalk": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+    "camelcase": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "dev": true,
+      "optional": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000865",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
+      "integrity": "sha512-vs79o1mOSKRGv/1pSkp4EXgl4ZviWeYReXw60XfacPU64uQWZwJT6vZNmxRF9O+6zu71sJwMxLK5JXxbzuVrLw=="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "4.4.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        }
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -2557,7 +935,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -2566,6 +944,27 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "cliui": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2573,53 +972,78 @@
       "dev": true
     },
     "code": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/code/-/code-4.0.0.tgz",
-      "integrity": "sha1-7HlT/XkZAFLOoladY9e0wNR8AgQ=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/code/-/code-4.1.0.tgz",
+      "integrity": "sha1-IJrRHQWvigwceq9pTZ+k0sfZW4U=",
       "dev": true,
       "requires": {
-        "hoek": "4.1.0"
+        "hoek": "4.x.x"
       },
       "dependencies": {
         "hoek": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.0.tgz",
-          "integrity": "sha1-SkVXRg9phC7UY6oAYozCbSaDr6c=",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
           "dev": true
         }
       }
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
+    },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+    },
+    "core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2633,19 +1057,43 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.9"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -2659,82 +1107,290 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "doctrine": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.52",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
+      "integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA="
+    },
+    "es5-ext": {
+      "version": "0.10.45",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "eslint": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.8.0.tgz",
-      "integrity": "sha1-Ip7w41Tg5h2DfHqA/fuoJeGZgV4=",
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.1.0",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.0.0",
-        "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
         "table": "4.0.2",
-        "text-table": "0.2.0"
+        "text-table": "~0.2.0"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.7.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+          "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
+      }
+    },
+    "eslint-config-hapi": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-10.1.0.tgz",
+      "integrity": "sha512-tAUedyvZla1qKt6jhOx7mj5tYDVCwdSyImpEK7wk/A/atKUjg18aHUK6Q6qWWM6rq21I1F/A8JAhIpkk0SvFMQ==",
+      "dev": true
+    },
+    "eslint-plugin-hapi": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.1.0.tgz",
+      "integrity": "sha512-z1yUoSWArx6pXaC0FoWRFpqjbHn8QWonJiTVhJmiC14jOAT7FZKdKWCkhM4jQrgrkEK9YEv3p2HuzSf5dtWmuQ==",
+      "dev": true,
+      "requires": {
+        "hapi-capitalize-modules": "1.x.x",
+        "hapi-for-you": "1.x.x",
+        "hapi-no-var": "1.x.x",
+        "hapi-scope-start": "2.x.x",
+        "no-arrowception": "1.x.x"
       }
     },
     "eslint-scope": {
@@ -2743,24 +1399,30 @@
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
     "espree": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
-      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-          "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+          "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
           "dev": true
         }
       }
@@ -2772,22 +1434,21 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -2799,24 +1460,57 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
     "external-editor": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
-      "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.19",
-        "jschardet": "1.5.1",
-        "tmp": "0.0.33"
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
     "fast-deep-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
@@ -2831,7 +1525,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -2840,9 +1534,15 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
+    },
+    "find-rc": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
+      "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
+      "dev": true
     },
     "flat-cache": {
       "version": "1.3.0",
@@ -2850,10 +1550,27 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -2868,25 +1585,48 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "dev": true
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globby": {
       "version": "5.0.0",
@@ -2894,12 +1634,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -2908,31 +1648,137 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
+      "requires": {
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "hapi-capitalize-modules": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
+      "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
+      "dev": true
+    },
+    "hapi-for-you": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
+      "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
+      "dev": true
+    },
+    "hapi-no-var": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hapi-no-var/-/hapi-no-var-1.0.1.tgz",
+      "integrity": "sha512-kk2xyyTzI+eQ/oA1rO4eVdCpYsrPHVERHa6+mTHD08XXFLaAkkaEs6reMg1VyqGh2o5xPt//DO4EhCacLx/cRA==",
+      "dev": true
+    },
+    "hapi-scope-start": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
+      "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      }
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "ignore": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
-      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "imurmurhash": {
@@ -2947,15 +1793,14 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "3.3.0",
@@ -2963,28 +1808,100 @@
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.1.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
-        "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
+      }
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -2993,6 +1910,25 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "dev": true,
+      "requires": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -3000,21 +1936,21 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-promise": {
@@ -3023,14 +1959,23 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
     "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -3038,32 +1983,70 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
+    "isemail": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
+      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
+    },
+    "joi": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
+      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
+      "requires": {
+        "hoek": "2.x.x",
+        "isemail": "1.x.x",
+        "moment": "2.x.x",
+        "topo": "1.x.x"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
-    "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -3078,8 +2061,25 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonify": {
       "version": "0.0.0",
@@ -3087,1961 +2087,343 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
     "jsonwebtoken": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-6.2.0.tgz",
       "integrity": "sha1-gjMVTGzZ/YdgrQ9aVj9TndOR8vk=",
       "requires": {
-        "joi": "6.10.1",
-        "jws": "3.1.4",
-        "ms": "0.7.2",
-        "xtend": "4.0.1"
+        "joi": "~6.10.1",
+        "jws": "^3.0.0",
+        "ms": "^0.7.1",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
-        "joi": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-          "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-          "requires": {
-            "hoek": "2.16.3",
-            "isemail": "1.2.0",
-            "moment": "2.17.1",
-            "topo": "1.1.0"
-          },
-          "dependencies": {
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-            },
-            "isemail": {
-              "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-              "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-            },
-            "moment": {
-              "version": "2.17.1",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
-              "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI="
-            },
-            "topo": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-              "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            }
-          }
-        },
-        "jws": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.4.tgz",
-          "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
-          "requires": {
-            "base64url": "2.0.0",
-            "jwa": "1.1.5",
-            "safe-buffer": "5.0.1"
-          },
-          "dependencies": {
-            "base64url": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/base64url/-/base64url-2.0.0.tgz",
-              "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-            },
-            "jwa": {
-              "version": "1.1.5",
-              "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-              "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
-              "requires": {
-                "base64url": "2.0.0",
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.9",
-                "safe-buffer": "5.0.1"
-              },
-              "dependencies": {
-                "buffer-equal-constant-time": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-                  "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-                },
-                "ecdsa-sig-formatter": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-                  "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
-                  "requires": {
-                    "base64url": "2.0.0",
-                    "safe-buffer": "5.0.1"
-                  }
-                }
-              }
-            },
-            "safe-buffer": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
-            }
-          }
-        },
         "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+          "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
         }
       }
     },
-    "lab": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lab/-/lab-11.2.1.tgz",
-      "integrity": "sha1-0cXhjx34N6PQujv/emcKqo/Bkh8=",
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
       "requires": {
-        "bossy": "3.0.4",
-        "diff": "3.2.0",
-        "eslint": "3.9.1",
-        "eslint-config-hapi": "10.0.0",
-        "eslint-plugin-hapi": "4.0.0",
-        "espree": "3.3.2",
-        "find-rc": "3.0.1",
-        "handlebars": "4.0.6",
-        "hoek": "4.1.0",
-        "items": "2.1.1",
-        "json-stable-stringify": "1.0.1",
-        "json-stringify-safe": "5.0.1",
-        "mkdirp": "0.5.1",
-        "seedrandom": "2.4.2",
-        "source-map-support": "0.4.8"
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+      "requires": {
+        "jwa": "^1.1.5",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lab": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lab/-/lab-11.2.2.tgz",
+      "integrity": "sha1-ASzTGDxcC28cDwIxoOVUNM55OIc=",
+      "dev": true,
+      "requires": {
+        "bossy": "3.x.x",
+        "diff": "3.x.x",
+        "eslint": "3.13.x",
+        "eslint-config-hapi": "10.x.x",
+        "eslint-plugin-hapi": "4.x.x",
+        "espree": "3.x.x",
+        "find-rc": "3.0.x",
+        "handlebars": "4.x.x",
+        "hoek": "4.x.x",
+        "items": "2.x.x",
+        "json-stable-stringify": "1.x.x",
+        "json-stringify-safe": "5.x.x",
+        "mkdirp": "0.5.x",
+        "seedrandom": "2.4.x",
+        "source-map-support": "0.4.x"
       },
       "dependencies": {
-        "bossy": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/bossy/-/bossy-3.0.4.tgz",
-          "integrity": "sha1-+a6fJugbQaMY9O4Ng2huSlwlB7k=",
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
-            "hoek": "4.1.0",
-            "joi": "10.1.0"
-          },
-          "dependencies": {
-            "joi": {
-              "version": "10.1.0",
-              "resolved": "https://registry.npmjs.org/joi/-/joi-10.1.0.tgz",
-              "integrity": "sha1-jDqHV3wVn/66EppQVPMjj579cVk=",
-              "dev": true,
-              "requires": {
-                "hoek": "4.1.0",
-                "isemail": "2.2.1",
-                "items": "2.1.1",
-                "topo": "2.0.2"
-              },
-              "dependencies": {
-                "isemail": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-                  "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
-                  "dev": true
-                },
-                "topo": {
-                  "version": "2.0.2",
-                  "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-                  "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-                  "dev": true,
-                  "requires": {
-                    "hoek": "4.1.0"
-                  }
-                }
-              }
-            }
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
-        "diff": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-          "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+        "ajv-keywords": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
           "dev": true
+        },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+          "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^1.0.1"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
         },
         "eslint": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.9.1.tgz",
-          "integrity": "sha1-WoWXcG/GBIvGBhrHVNSiEdKPT1s=",
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.13.1.tgz",
+          "integrity": "sha1-Vk0mRrXv3thd+WmFMy7dkaI7/yU=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.20.0",
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.0",
-            "debug": "2.6.0",
-            "doctrine": "1.5.0",
-            "escope": "3.6.0",
-            "espree": "3.3.2",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "2.0.0",
-            "glob": "7.1.1",
-            "globals": "9.14.0",
-            "ignore": "3.2.0",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.15.0",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.7.0",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.4",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "optionator": "0.8.2",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.3",
-            "shelljs": "0.7.6",
-            "strip-bom": "3.0.0",
-            "strip-json-comments": "1.0.4",
-            "table": "3.8.3",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
-          },
-          "dependencies": {
-            "babel-code-frame": {
-              "version": "6.20.0",
-              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
-              "integrity": "sha1-uWj4OQkPmovG1Bk4+5bLhPc4eyY=",
-              "dev": true,
-              "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "2.0.0"
-              },
-              "dependencies": {
-                "js-tokens": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                  "integrity": "sha1-eZA/VWPud4zBFi5tzxoAJ8l/nLU=",
-                  "dev": true
-                }
-              }
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                  "dev": true
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                  "dev": true
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                      "dev": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                      "dev": true
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                  "dev": true
-                }
-              }
-            },
-            "concat-stream": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-              "dev": true,
-              "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.2.2",
-                "typedarray": "0.0.6"
-              },
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
-                },
-                "readable-stream": {
-                  "version": "2.2.2",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                  "integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
-                  "dev": true,
-                  "requires": {
-                    "buffer-shims": "1.0.0",
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "1.0.0",
-                    "process-nextick-args": "1.0.7",
-                    "string_decoder": "0.10.31",
-                    "util-deprecate": "1.0.2"
-                  },
-                  "dependencies": {
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                      "dev": true
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                      "dev": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                      "dev": true
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-                  "dev": true
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-              "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-              "dev": true,
-              "requires": {
-                "ms": "0.7.2"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.2",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                  "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-                  "dev": true
-                }
-              }
-            },
-            "doctrine": {
-              "version": "1.5.0",
-              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-              "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-              "dev": true,
-              "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
-              },
-              "dependencies": {
-                "isarray": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                  "dev": true
-                }
-              }
-            },
-            "escope": {
-              "version": "3.6.0",
-              "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-              "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-              "dev": true,
-              "requires": {
-                "es6-map": "0.1.4",
-                "es6-weak-map": "2.0.1",
-                "esrecurse": "4.1.0",
-                "estraverse": "4.2.0"
-              },
-              "dependencies": {
-                "es6-map": {
-                  "version": "0.1.4",
-                  "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
-                  "integrity": "sha1-o0sUe+IkdzpNfagHJ5TO+jYyuJc=",
-                  "dev": true,
-                  "requires": {
-                    "d": "0.1.1",
-                    "es5-ext": "0.10.12",
-                    "es6-iterator": "2.0.0",
-                    "es6-set": "0.1.4",
-                    "es6-symbol": "3.1.0",
-                    "event-emitter": "0.3.4"
-                  },
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-                      "dev": true,
-                      "requires": {
-                        "es5-ext": "0.10.12"
-                      }
-                    },
-                    "es5-ext": {
-                      "version": "0.10.12",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-                      "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
-                      "dev": true,
-                      "requires": {
-                        "es6-iterator": "2.0.0",
-                        "es6-symbol": "3.1.0"
-                      }
-                    },
-                    "es6-iterator": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12",
-                        "es6-symbol": "3.1.0"
-                      }
-                    },
-                    "es6-set": {
-                      "version": "0.1.4",
-                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-                      "integrity": "sha1-lRa2dhwpZLkv9HlFYjOiR9xwfOg=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12",
-                        "es6-iterator": "2.0.0",
-                        "es6-symbol": "3.1.0",
-                        "event-emitter": "0.3.4"
-                      }
-                    },
-                    "es6-symbol": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-                      "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12"
-                      }
-                    },
-                    "event-emitter": {
-                      "version": "0.3.4",
-                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-                      "integrity": "sha1-jWPd+0z+H647MsomXExyAiIIC7U=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12"
-                      }
-                    }
-                  }
-                },
-                "es6-weak-map": {
-                  "version": "2.0.1",
-                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-                  "integrity": "sha1-DSu9iCfrX7S6j5f7/qUNQ9sh6oE=",
-                  "dev": true,
-                  "requires": {
-                    "d": "0.1.1",
-                    "es5-ext": "0.10.12",
-                    "es6-iterator": "2.0.0",
-                    "es6-symbol": "3.1.0"
-                  },
-                  "dependencies": {
-                    "d": {
-                      "version": "0.1.1",
-                      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
-                      "dev": true,
-                      "requires": {
-                        "es5-ext": "0.10.12"
-                      }
-                    },
-                    "es5-ext": {
-                      "version": "0.10.12",
-                      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-                      "integrity": "sha1-qoRkHU23a2Krul5F/YBey6sUAEc=",
-                      "dev": true,
-                      "requires": {
-                        "es6-iterator": "2.0.0",
-                        "es6-symbol": "3.1.0"
-                      }
-                    },
-                    "es6-iterator": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                      "integrity": "sha1-vZaFZ9YWNeM8C4BydhPJy0sJa6w=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12",
-                        "es6-symbol": "3.1.0"
-                      }
-                    },
-                    "es6-symbol": {
-                      "version": "3.1.0",
-                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-                      "integrity": "sha1-lEgcZV56fK2C66gy2X1UM0ltf/o=",
-                      "dev": true,
-                      "requires": {
-                        "d": "0.1.1",
-                        "es5-ext": "0.10.12"
-                      }
-                    }
-                  }
-                },
-                "esrecurse": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-                  "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
-                  "dev": true,
-                  "requires": {
-                    "estraverse": "4.1.1",
-                    "object-assign": "4.1.0"
-                  },
-                  "dependencies": {
-                    "estraverse": {
-                      "version": "4.1.1",
-                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-                      "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-                      "dev": true
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "estraverse": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-              "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-              "dev": true
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-              "dev": true
-            },
-            "file-entry-cache": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-              "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-              "dev": true,
-              "requires": {
-                "flat-cache": "1.2.2",
-                "object-assign": "4.1.0"
-              },
-              "dependencies": {
-                "flat-cache": {
-                  "version": "1.2.2",
-                  "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-                  "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-                  "dev": true,
-                  "requires": {
-                    "circular-json": "0.3.1",
-                    "del": "2.2.2",
-                    "graceful-fs": "4.1.11",
-                    "write": "0.2.1"
-                  },
-                  "dependencies": {
-                    "circular-json": {
-                      "version": "0.3.1",
-                      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-                      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
-                      "dev": true
-                    },
-                    "del": {
-                      "version": "2.2.2",
-                      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-                      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-                      "dev": true,
-                      "requires": {
-                        "globby": "5.0.0",
-                        "is-path-cwd": "1.0.0",
-                        "is-path-in-cwd": "1.0.0",
-                        "object-assign": "4.1.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "rimraf": "2.5.4"
-                      },
-                      "dependencies": {
-                        "globby": {
-                          "version": "5.0.0",
-                          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-                          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-                          "dev": true,
-                          "requires": {
-                            "array-union": "1.0.2",
-                            "arrify": "1.0.1",
-                            "glob": "7.1.1",
-                            "object-assign": "4.1.0",
-                            "pify": "2.3.0",
-                            "pinkie-promise": "2.0.1"
-                          },
-                          "dependencies": {
-                            "array-union": {
-                              "version": "1.0.2",
-                              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-                              "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-                              "dev": true,
-                              "requires": {
-                                "array-uniq": "1.0.3"
-                              },
-                              "dependencies": {
-                                "array-uniq": {
-                                  "version": "1.0.3",
-                                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-                                  "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "arrify": {
-                              "version": "1.0.1",
-                              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                              "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "is-path-cwd": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-                          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-                          "dev": true
-                        },
-                        "is-path-in-cwd": {
-                          "version": "1.0.0",
-                          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                          "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-                          "dev": true,
-                          "requires": {
-                            "is-path-inside": "1.0.0"
-                          },
-                          "dependencies": {
-                            "is-path-inside": {
-                              "version": "1.0.0",
-                              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-                              "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-                              "dev": true,
-                              "requires": {
-                                "path-is-inside": "1.0.2"
-                              }
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                          "dev": true
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                          "dev": true,
-                          "requires": {
-                            "pinkie": "2.0.4"
-                          },
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "rimraf": {
-                          "version": "2.5.4",
-                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-                          "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-                          "dev": true,
-                          "requires": {
-                            "glob": "7.1.1"
-                          }
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                      "dev": true
-                    },
-                    "write": {
-                      "version": "0.2.1",
-                      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-                      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-                      "dev": true,
-                      "requires": {
-                        "mkdirp": "0.5.1"
-                      }
-                    }
-                  }
-                },
-                "object-assign": {
-                  "version": "4.1.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                  "dev": true
-                }
-              }
-            },
-            "glob": {
-              "version": "7.1.1",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-              "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-              "dev": true,
-              "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.3",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-              },
-              "dependencies": {
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                  "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-                  "dev": true
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                  "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-                  "dev": true,
-                  "requires": {
-                    "once": "1.4.0",
-                    "wrappy": "1.0.2"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                  "dev": true
-                },
-                "minimatch": {
-                  "version": "3.0.3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "1.1.6"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                      "dev": true,
-                      "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                  "dev": true,
-                  "requires": {
-                    "wrappy": "1.0.2"
-                  },
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-                  "dev": true
-                }
-              }
-            },
-            "globals": {
-              "version": "9.14.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-              "integrity": "sha1-iFmTavADh0EmMFOznQ52yiQeQDQ=",
-              "dev": true
-            },
-            "ignore": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz",
-              "integrity": "sha1-jYjwPDACoKxSEU2yXSxnOwvx5DU=",
-              "dev": true
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-              "dev": true
-            },
-            "inquirer": {
-              "version": "0.12.0",
-              "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-              "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-              "dev": true,
-              "requires": {
-                "ansi-escapes": "1.4.0",
-                "ansi-regex": "2.0.0",
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-width": "2.1.0",
-                "figures": "1.7.0",
-                "lodash": "4.17.4",
-                "readline2": "1.0.1",
-                "run-async": "0.1.0",
-                "rx-lite": "3.1.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
-              },
-              "dependencies": {
-                "ansi-escapes": {
-                  "version": "1.4.0",
-                  "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-                  "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
-                  "dev": true
-                },
-                "ansi-regex": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                  "dev": true
-                },
-                "cli-cursor": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-                  "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-                  "dev": true,
-                  "requires": {
-                    "restore-cursor": "1.0.1"
-                  },
-                  "dependencies": {
-                    "restore-cursor": {
-                      "version": "1.0.1",
-                      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-                      "dev": true,
-                      "requires": {
-                        "exit-hook": "1.1.1",
-                        "onetime": "1.1.0"
-                      },
-                      "dependencies": {
-                        "exit-hook": {
-                          "version": "1.1.1",
-                          "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-                          "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
-                          "dev": true
-                        },
-                        "onetime": {
-                          "version": "1.1.0",
-                          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "cli-width": {
-                  "version": "2.1.0",
-                  "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-                  "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
-                  "dev": true
-                },
-                "figures": {
-                  "version": "1.7.0",
-                  "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-                  "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-                  "dev": true,
-                  "requires": {
-                    "escape-string-regexp": "1.0.5",
-                    "object-assign": "4.1.0"
-                  },
-                  "dependencies": {
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                      "dev": true
-                    },
-                    "object-assign": {
-                      "version": "4.1.0",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                      "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                      "dev": true
-                    }
-                  }
-                },
-                "readline2": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-                  "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "mute-stream": "0.0.5"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                      "dev": true
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                      "dev": true,
-                      "requires": {
-                        "number-is-nan": "1.0.1"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "mute-stream": {
-                      "version": "0.0.5",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-                      "dev": true
-                    }
-                  }
-                },
-                "run-async": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-                  "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-                  "dev": true,
-                  "requires": {
-                    "once": "1.4.0"
-                  },
-                  "dependencies": {
-                    "once": {
-                      "version": "1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-                      "dev": true,
-                      "requires": {
-                        "wrappy": "1.0.2"
-                      },
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "rx-lite": {
-                  "version": "3.1.2",
-                  "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-                  "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
-                  "dev": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
-                  "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
-                  },
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                      "dev": true
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                      "dev": true,
-                      "requires": {
-                        "number-is-nan": "1.0.1"
-                      },
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  }
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-                  "dev": true
-                }
-              }
-            },
-            "is-my-json-valid": {
-              "version": "2.15.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-              "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-              "dev": true,
-              "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
-              },
-              "dependencies": {
-                "generate-function": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                  "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-                  "dev": true
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-                  "dev": true,
-                  "requires": {
-                    "is-property": "1.0.2"
-                  },
-                  "dependencies": {
-                    "is-property": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                      "dev": true
-                    }
-                  }
-                },
-                "jsonpointer": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-                  "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-                  "dev": true
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-                  "dev": true
-                }
-              }
-            },
-            "is-resolvable": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-              "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-              "dev": true,
-              "requires": {
-                "tryit": "1.0.3"
-              },
-              "dependencies": {
-                "tryit": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-                  "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-                  "dev": true
-                }
-              }
-            },
-            "js-yaml": {
-              "version": "3.7.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-              "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-              "dev": true,
-              "requires": {
-                "argparse": "1.0.9",
-                "esprima": "2.7.3"
-              },
-              "dependencies": {
-                "argparse": {
-                  "version": "1.0.9",
-                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                  "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-                  "dev": true,
-                  "requires": {
-                    "sprintf-js": "1.0.3"
-                  },
-                  "dependencies": {
-                    "sprintf-js": {
-                      "version": "1.0.3",
-                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-                      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-                      "dev": true
-                    }
-                  }
-                },
-                "esprima": {
-                  "version": "2.7.3",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                  "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-                  "dev": true
-                }
-              }
-            },
-            "levn": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-              "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-              "dev": true,
-              "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
-              },
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-                  "dev": true
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                  "dev": true,
-                  "requires": {
-                    "prelude-ls": "1.1.2"
-                  }
-                }
-              }
-            },
-            "lodash": {
-              "version": "4.17.4",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-              "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-              "dev": true
-            },
-            "natural-compare": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-              "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-              "dev": true
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-              "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-              "dev": true,
-              "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
-              },
-              "dependencies": {
-                "deep-is": {
-                  "version": "0.1.3",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                  "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-                  "dev": true
-                },
-                "fast-levenshtein": {
-                  "version": "2.0.6",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-                  "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-                  "dev": true
-                },
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-                  "dev": true
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-                  "dev": true,
-                  "requires": {
-                    "prelude-ls": "1.1.2"
-                  }
-                },
-                "wordwrap": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                  "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-                  "dev": true
-                }
-              }
-            },
-            "path-is-inside": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-              "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-              "dev": true
-            },
-            "pluralize": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-              "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
-              "dev": true
-            },
-            "progress": {
-              "version": "1.1.8",
-              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-              "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
-              "dev": true
-            },
-            "require-uncached": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-              "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-              "dev": true,
-              "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
-              },
-              "dependencies": {
-                "caller-path": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-                  "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-                  "dev": true,
-                  "requires": {
-                    "callsites": "0.2.0"
-                  },
-                  "dependencies": {
-                    "callsites": {
-                      "version": "0.2.0",
-                      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-                      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-                      "dev": true
-                    }
-                  }
-                },
-                "resolve-from": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-                  "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-                  "dev": true
-                }
-              }
-            },
-            "shelljs": {
-              "version": "0.7.6",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.6.tgz",
-              "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
-              "dev": true,
-              "requires": {
-                "glob": "7.1.1",
-                "interpret": "1.0.1",
-                "rechoir": "0.6.2"
-              },
-              "dependencies": {
-                "interpret": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-                  "integrity": "sha1-1Xn7f2k7hYAElHrzn6DbSfeVYCw=",
-                  "dev": true
-                },
-                "rechoir": {
-                  "version": "0.6.2",
-                  "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-                  "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-                  "dev": true,
-                  "requires": {
-                    "resolve": "1.2.0"
-                  },
-                  "dependencies": {
-                    "resolve": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
-                      "integrity": "sha1-lYnD8vYUnRQXpAvswWY9tuxrwmw=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "strip-bom": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-              "dev": true
-            },
-            "strip-json-comments": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-              "dev": true
-            },
-            "table": {
-              "version": "3.8.3",
-              "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-              "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
-              "dev": true,
-              "requires": {
-                "ajv": "4.10.4",
-                "ajv-keywords": "1.5.0",
-                "chalk": "1.1.3",
-                "lodash": "4.17.4",
-                "slice-ansi": "0.0.4",
-                "string-width": "2.0.0"
-              },
-              "dependencies": {
-                "ajv": {
-                  "version": "4.10.4",
-                  "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.10.4.tgz",
-                  "integrity": "sha1-wJdN0As0ZJhIktYBCqnCyUWTMlQ=",
-                  "dev": true,
-                  "requires": {
-                    "co": "4.6.0",
-                    "json-stable-stringify": "1.0.1"
-                  },
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-                      "dev": true
-                    }
-                  }
-                },
-                "ajv-keywords": {
-                  "version": "1.5.0",
-                  "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.0.tgz",
-                  "integrity": "sha1-wR5oWer/+D4Nr8QWkpRy7KlGqiw=",
-                  "dev": true
-                },
-                "slice-ansi": {
-                  "version": "0.0.4",
-                  "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-                  "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-                  "dev": true
-                },
-                "string-width": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-                  "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-                  "dev": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "3.0.1"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                      "dev": true
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "2.0.0"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-              "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-              "dev": true
-            },
-            "user-home": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-              "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-              "dev": true,
-              "requires": {
-                "os-homedir": "1.0.2"
-              },
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-                  "dev": true
-                }
-              }
-            }
+            "babel-code-frame": "^6.16.0",
+            "chalk": "^1.1.3",
+            "concat-stream": "^1.4.6",
+            "debug": "^2.1.1",
+            "doctrine": "^1.2.2",
+            "escope": "^3.6.0",
+            "espree": "^3.3.1",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "glob": "^7.0.3",
+            "globals": "^9.14.0",
+            "ignore": "^3.2.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^0.12.0",
+            "is-my-json-valid": "^2.10.0",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.5.1",
+            "json-stable-stringify": "^1.0.0",
+            "levn": "^0.3.0",
+            "lodash": "^4.0.0",
+            "mkdirp": "^0.5.0",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.1",
+            "pluralize": "^1.2.1",
+            "progress": "^1.1.8",
+            "require-uncached": "^1.0.2",
+            "shelljs": "^0.7.5",
+            "strip-bom": "^3.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "^3.7.8",
+            "text-table": "~0.2.0",
+            "user-home": "^2.0.0"
           }
         },
-        "eslint-config-hapi": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-10.0.0.tgz",
-          "integrity": "sha1-mYCv/XYQPrwf7JK0Vjg0XbGTSPU=",
-          "dev": true
-        },
-        "eslint-plugin-hapi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.0.0.tgz",
-          "integrity": "sha1-RKouRfeTmlI5Kc2DK7mqEpqV6CM=",
+        "figures": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+          "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "hapi-capitalize-modules": "1.1.6",
-            "hapi-for-you": "1.0.0",
-            "hapi-scope-start": "2.1.1",
-            "no-arrowception": "1.0.0"
-          },
-          "dependencies": {
-            "hapi-capitalize-modules": {
-              "version": "1.1.6",
-              "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
-              "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
-              "dev": true
-            },
-            "hapi-for-you": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
-              "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
-              "dev": true
-            },
-            "hapi-scope-start": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
-              "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
-              "dev": true
-            },
-            "no-arrowception": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
-              "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
-              "dev": true
-            }
-          }
-        },
-        "espree": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz",
-          "integrity": "sha1-2/P63rTstNR3gwPlAQOz02yIuJw=",
-          "dev": true,
-          "requires": {
-            "acorn": "4.0.4",
-            "acorn-jsx": "3.0.1"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "4.0.4",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
-              "integrity": "sha1-F6jWp6bE71OLgU7Jq6wneSk78wo=",
-              "dev": true
-            },
-            "acorn-jsx": {
-              "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-              "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-              "dev": true,
-              "requires": {
-                "acorn": "3.3.0"
-              },
-              "dependencies": {
-                "acorn": {
-                  "version": "3.3.0",
-                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-                  "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "find-rc": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
-          "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.6",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-          "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.7.5"
-          },
-          "dependencies": {
-            "async": {
-              "version": "1.5.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-              "dev": true
-            },
-            "optimist": {
-              "version": "0.6.1",
-              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
-              },
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.10",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                  "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-                  "dev": true
-                },
-                "wordwrap": {
-                  "version": "0.0.3",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-                  "dev": true
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              },
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                  "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-                  "dev": true
-                }
-              }
-            },
-            "uglify-js": {
-              "version": "2.7.5",
-              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
-              "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "async": "0.2.10",
-                "source-map": "0.5.6",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
-              },
-              "dependencies": {
-                "async": {
-                  "version": "0.2.10",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                  "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-                  "dev": true,
-                  "optional": true
-                },
-                "source-map": {
-                  "version": "0.5.6",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                  "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
-                  "dev": true,
-                  "optional": true
-                },
-                "uglify-to-browserify": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-                  "dev": true,
-                  "optional": true
-                },
-                "yargs": {
-                  "version": "3.10.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "camelcase": "1.2.1",
-                    "cliui": "2.1.0",
-                    "decamelize": "1.2.0",
-                    "window-size": "0.1.0"
-                  },
-                  "dependencies": {
-                    "camelcase": {
-                      "version": "1.2.1",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "cliui": {
-                      "version": "2.1.0",
-                      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-                      "dev": true,
-                      "optional": true,
-                      "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
-                        "wordwrap": "0.0.2"
-                      },
-                      "dependencies": {
-                        "center-align": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "align-text": "0.1.4",
-                            "lazy-cache": "1.0.4"
-                          },
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "kind-of": "3.1.0",
-                                "longest": "1.0.1",
-                                "repeat-string": "1.6.1"
-                              },
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.1.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                                  "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "is-buffer": "1.1.4"
-                                  },
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.4",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-                                      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                  "dev": true,
-                                  "optional": true
-                                },
-                                "repeat-string": {
-                                  "version": "1.6.1",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                  "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-                                  "dev": true,
-                                  "optional": true
-                                }
-                              }
-                            },
-                            "lazy-cache": {
-                              "version": "1.0.4",
-                              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-                              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-                              "dev": true,
-                              "optional": true
-                            }
-                          }
-                        },
-                        "right-align": {
-                          "version": "0.1.3",
-                          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-                          "dev": true,
-                          "optional": true,
-                          "requires": {
-                            "align-text": "0.1.4"
-                          },
-                          "dependencies": {
-                            "align-text": {
-                              "version": "0.1.4",
-                              "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-                              "dev": true,
-                              "optional": true,
-                              "requires": {
-                                "kind-of": "3.1.0",
-                                "longest": "1.0.1",
-                                "repeat-string": "1.6.1"
-                              },
-                              "dependencies": {
-                                "kind-of": {
-                                  "version": "3.1.0",
-                                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                                  "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-                                  "dev": true,
-                                  "optional": true,
-                                  "requires": {
-                                    "is-buffer": "1.1.4"
-                                  },
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.4",
-                                      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-                                      "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys=",
-                                      "dev": true,
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "longest": {
-                                  "version": "1.0.1",
-                                  "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-                                  "dev": true,
-                                  "optional": true
-                                },
-                                "repeat-string": {
-                                  "version": "1.6.1",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                  "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-                                  "dev": true,
-                                  "optional": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "wordwrap": {
-                          "version": "0.0.2",
-                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-                          "dev": true,
-                          "optional": true
-                        }
-                      }
-                    },
-                    "decamelize": {
-                      "version": "1.2.0",
-                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "window-size": {
-                      "version": "0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            }
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "hoek": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.0.tgz",
-          "integrity": "sha1-SkVXRg9phC7UY6oAYozCbSaDr6c=",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
           "dev": true
         },
-        "items": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-          "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
+        "inquirer": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^1.1.0",
+            "ansi-regex": "^2.0.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "readline2": "^1.0.1",
+            "run-async": "^0.1.0",
+            "rx-lite": "^3.1.2",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
         },
-        "json-stable-stringify": {
+        "onetime": {
+          "version": "1.1.0",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+          "dev": true
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+          "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+          "dev": true
+        },
+        "progress": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+          "dev": true
+        },
+        "restore-cursor": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+          "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
-          },
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-              "dev": true
-            }
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+        "run-async": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+          "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
           "dev": true,
           "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
+            "once": "^1.3.0"
           }
         },
-        "seedrandom": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.2.tgz",
-          "integrity": "sha1-GNeMQSh9E6/46tsp4jWTiySKqf8=",
+        "rx-lite": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+          "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
           "dev": true
         },
-        "source-map-support": {
-          "version": "0.4.8",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.8.tgz",
-          "integrity": "sha1-SHGRjYo68HKJGC6XTjKEQyey6Ys=",
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "source-map": "0.5.6"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "table": {
+          "version": "3.8.3",
+          "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+          "dev": true,
+          "requires": {
+            "ajv": "^4.7.0",
+            "ajv-keywords": "^1.0.0",
+            "chalk": "^1.1.1",
+            "lodash": "^4.0.0",
+            "slice-ansi": "0.0.4",
+            "string-width": "^2.0.0"
           },
           "dependencies": {
-            "source-map": {
-              "version": "0.5.6",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
               "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "dev": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
             }
           }
         }
       }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
     },
     "levn": {
       "version": "0.3.0",
@@ -5049,8 +2431,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "lodash": {
@@ -5058,14 +2440,28 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
     },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
     "lru-cache": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "magic-string": {
@@ -5073,51 +2469,60 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.16.0.tgz",
       "integrity": "sha1-lw67DacZMwEoX7GqZQ85vdgetFo=",
       "requires": {
-        "vlq": "0.2.1"
-      },
-      "dependencies": {
-        "vlq": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.1.tgz",
-          "integrity": "sha1-FEOdcRiR5oJTVGf4WHxWMOQiKmw="
-        }
+        "vlq": "^0.2.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.33.0"
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -5129,6 +2534,29 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "no-arrowception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
+      "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
       "dev": true
     },
     "object-assign": {
@@ -5143,7 +2571,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -5152,7 +2580,25 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -5161,30 +2607,45 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "pify": {
@@ -5205,7 +2666,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pluralize": {
@@ -5220,10 +2681,15 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
+    },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
     },
     "progress": {
@@ -5238,581 +2704,177 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
     "raw-body": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
-      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "requires": {
-        "bytes": "2.4.0",
-        "iconv-lite": "0.4.15",
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-          "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
-        },
-        "iconv-lite": {
-          "version": "0.4.15",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-          "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-        }
       }
     },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "mute-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+          "dev": true
+        }
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "requires": {
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
+      }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "requires": {
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
+        }
+      }
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.5.0",
-        "caseless": "0.11.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.0",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.2",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.13",
-        "oauth-sign": "0.8.2",
-        "qs": "6.3.0",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.4.3",
-        "uuid": "3.0.1"
-      },
-      "dependencies": {
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "aws4": {
-          "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
-          "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          },
-          "dependencies": {
-            "delayed-stream": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-              "dev": true
-            }
-          }
-        },
-        "extend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-          "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.13"
-          },
-          "dependencies": {
-            "asynckit": {
-              "version": "0.4.0",
-              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-              "dev": true
-            }
-          }
-        },
-        "har-validator": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "commander": "2.9.0",
-            "is-my-json-valid": "2.15.0",
-            "pinkie-promise": "2.0.1"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              },
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                  "dev": true
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                  "dev": true
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                      "dev": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.0.0"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
-                      "dev": true
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                  "dev": true
-                }
-              }
-            },
-            "commander": {
-              "version": "2.9.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-              "dev": true,
-              "requires": {
-                "graceful-readlink": "1.0.1"
-              },
-              "dependencies": {
-                "graceful-readlink": {
-                  "version": "1.0.1",
-                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                  "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-                  "dev": true
-                }
-              }
-            },
-            "is-my-json-valid": {
-              "version": "2.15.0",
-              "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-              "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-              "dev": true,
-              "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
-              },
-              "dependencies": {
-                "generate-function": {
-                  "version": "2.0.0",
-                  "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                  "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-                  "dev": true
-                },
-                "generate-object-property": {
-                  "version": "1.2.0",
-                  "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                  "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-                  "dev": true,
-                  "requires": {
-                    "is-property": "1.0.2"
-                  },
-                  "dependencies": {
-                    "is-property": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                      "dev": true
-                    }
-                  }
-                },
-                "jsonpointer": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-                  "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-                  "dev": true
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-                  "dev": true
-                }
-              }
-            },
-            "pinkie-promise": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-              "dev": true,
-              "requires": {
-                "pinkie": "2.0.4"
-              },
-              "dependencies": {
-                "pinkie": {
-                  "version": "2.0.4",
-                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "2.10.1",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-              "dev": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            },
-            "cryptiles": {
-              "version": "2.0.5",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-              "dev": true,
-              "requires": {
-                "boom": "2.10.1"
-              }
-            },
-            "hoek": {
-              "version": "2.16.3",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-              "dev": true
-            },
-            "sntp": {
-              "version": "1.0.9",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-              "dev": true,
-              "requires": {
-                "hoek": "2.16.3"
-              }
-            }
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.3.1",
-            "sshpk": "1.10.1"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-              "dev": true
-            },
-            "jsprim": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-              "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
-              "dev": true,
-              "requires": {
-                "extsprintf": "1.0.2",
-                "json-schema": "0.2.3",
-                "verror": "1.3.6"
-              },
-              "dependencies": {
-                "extsprintf": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                  "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                  "dev": true
-                },
-                "json-schema": {
-                  "version": "0.2.3",
-                  "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                  "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-                  "dev": true
-                },
-                "verror": {
-                  "version": "1.3.6",
-                  "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                  "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                  "dev": true,
-                  "requires": {
-                    "extsprintf": "1.0.2"
-                  }
-                }
-              }
-            },
-            "sshpk": {
-              "version": "1.10.1",
-              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
-              "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
-              "dev": true,
-              "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.0",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.6",
-                "jodid25519": "1.0.2",
-                "jsbn": "0.1.0",
-                "tweetnacl": "0.14.5"
-              },
-              "dependencies": {
-                "asn1": {
-                  "version": "0.2.3",
-                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                  "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                  "dev": true
-                },
-                "assert-plus": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                  "dev": true
-                },
-                "bcrypt-pbkdf": {
-                  "version": "1.0.0",
-                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                  "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "tweetnacl": "0.14.5"
-                  }
-                },
-                "dashdash": {
-                  "version": "1.14.1",
-                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                  "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                  "dev": true,
-                  "requires": {
-                    "assert-plus": "1.0.0"
-                  }
-                },
-                "ecc-jsbn": {
-                  "version": "0.1.1",
-                  "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                  "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "jsbn": "0.1.0"
-                  }
-                },
-                "getpass": {
-                  "version": "0.1.6",
-                  "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                  "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-                  "dev": true,
-                  "requires": {
-                    "assert-plus": "1.0.0"
-                  }
-                },
-                "jodid25519": {
-                  "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                  "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "jsbn": "0.1.0"
-                  }
-                },
-                "jsbn": {
-                  "version": "0.1.0",
-                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                  "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
-                  "dev": true,
-                  "optional": true
-                },
-                "tweetnacl": {
-                  "version": "0.14.5",
-                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-                  "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-                  "dev": true,
-                  "optional": true
-                }
-              }
-            }
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-          "dev": true
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.13",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-          "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.25.0"
-          },
-          "dependencies": {
-            "mime-db": {
-              "version": "1.25.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
-              "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
-              "dev": true
-            }
-          }
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-          "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
-          "dev": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-          "dev": true
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-              "dev": true
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-          "dev": true
-        }
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-uncached": {
@@ -5821,8 +2883,17 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -5837,8 +2908,18 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -5847,7 +2928,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -5856,7 +2937,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rx-lite": {
@@ -5871,20 +2952,34 @@
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "dev": true,
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "seedrandom": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
+      "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
       "dev": true
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -5892,7 +2987,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -5901,49 +2996,53 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
-    "shot": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.0.tgz",
-      "integrity": "sha1-5xJe5yV1rlIYNJ6TNjaAjXkNS5I=",
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
       "requires": {
-        "hoek": "4.1.0",
-        "joi": "10.1.0"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "shot": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.2.tgz",
+      "integrity": "sha1-Hlw/bysmZJrcQvfrNQIUpaApHWc=",
+      "requires": {
+        "hoek": "4.x.x",
+        "joi": "10.x.x"
       },
       "dependencies": {
         "hoek": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.0.tgz",
-          "integrity": "sha1-SkVXRg9phC7UY6oAYozCbSaDr6c="
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+          "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+        },
+        "isemail": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+          "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
         },
         "joi": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-10.1.0.tgz",
-          "integrity": "sha1-jDqHV3wVn/66EppQVPMjj579cVk=",
+          "version": "10.6.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+          "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.1.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
-          },
-          "dependencies": {
-            "isemail": {
-              "version": "2.2.1",
-              "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-              "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
-            },
-            "items": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
-              "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
-            },
-            "topo": {
-              "version": "2.0.2",
-              "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-              "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-              "requires": {
-                "hoek": "4.1.0"
-              }
-            }
+            "hoek": "4.x.x",
+            "isemail": "2.x.x",
+            "items": "2.x.x",
+            "topo": "2.x.x"
+          }
+        },
+        "topo": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+          "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+          "requires": {
+            "hoek": "4.x.x"
           }
         }
       }
@@ -5954,13 +3053,31 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+    },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "requires": {
+        "source-map": "^0.5.6"
       }
     },
     "sprintf-js": {
@@ -5969,32 +3086,36 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "3.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -6002,8 +3123,40 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
         }
       }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -6014,8 +3167,7 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "table": {
       "version": "4.0.2",
@@ -6023,19 +3175,48 @@
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3",
-        "ajv-keywords": "2.1.0",
-        "chalk": "2.1.0",
-        "lodash": "4.17.4",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
           "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -6057,14 +3238,51 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
-    "tryit": {
+    "to-fast-properties": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "topo": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
+      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.4.1"
+      }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -6072,7 +3290,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -6081,20 +3299,82 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "uglify-js": {
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
+    },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -6114,14 +3394,32 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "acorn": "^3.2.0",
     "async": "^2.0.0-rc.5",
     "babel-core": "6.26.3",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "jsonwebtoken": "^6.1.0",
     "lodash": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webtask-runtime",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Runtime components of the webtask.io sandbox",
   "main": "index.js",
   "directories": {
@@ -9,7 +9,8 @@
   "dependencies": {
     "acorn": "^3.2.0",
     "async": "^2.0.0-rc.5",
-    "babel": "^5.8.38",
+    "babel-core": "6.26.3",
+    "babel-preset-env": "^1.7.0",
     "jsonwebtoken": "^6.1.0",
     "lodash": "^3.10.1",
     "magic-string": "^0.16.0",


### PR DESCRIPTION
`wt-cli` is showing a deprecation warning for `minimatch`. Running `npm ls minimatch` shows:
```
wt-cli@10.0.1 /Users/sky/Desktop/Dev/Auth0/wt-cli
├─┬ eslint@4.19.1
│ ├─┬ file-entry-cache@2.0.0
│ │ └─┬ flat-cache@1.3.0
│ │   └─┬ del@2.2.2
│ │     ├─┬ globby@5.0.0
│ │     │ └─┬ glob@7.1.2
│ │     │   └── minimatch@3.0.4  deduped
│ │     └─┬ rimraf@2.6.2
│ │       └─┬ glob@7.1.2
│ │         └── minimatch@3.0.4  deduped
│ ├─┬ glob@7.1.2
│ │ └── minimatch@3.0.4  deduped
│ └── minimatch@3.0.4  deduped
├── minimatch@3.0.4
├─┬ webtask-bundle@3.2.2
│ ├─┬ glob@6.0.4
│ │ └── minimatch@3.0.4  deduped
│ └─┬ webpack@4.15.1
│   └─┬ uglifyjs-webpack-plugin@1.2.7
│     └─┬ cacache@10.0.4
│       └─┬ glob@7.1.2
│         └── minimatch@3.0.4  deduped
└─┬ webtask-runtime@1.7.0
  └─┬ babel@5.8.38
    ├─┬ babel-core@5.8.38
    │ ├── minimatch@2.0.10   <--- Notice the deprecated version here
    │ └─┬ regenerator@0.8.40
    │   └─┬ commoner@0.10.8
    │     └─┬ glob@5.0.15
    │       └── minimatch@3.0.4  deduped
    ├─┬ chokidar@1.7.0
    │ ├─┬ fsevents@1.2.4
    │ │ └─┬ node-pre-gyp@0.10.0
    │ │   ├─┬ npm-packlist@1.1.10
    │ │   │ └─┬ ignore-walk@3.0.1
    │ │   │   └── minimatch@3.0.4
    │ │   └─┬ rimraf@2.6.2
    │ │     └─┬ glob@7.1.2
    │ │       └── minimatch@3.0.4  deduped
    │ └─┬ readdirp@2.1.0
    │   └── minimatch@3.0.4  deduped
    └─┬ glob@5.0.15
      └── minimatch@3.0.4  deduped
```
Notice that `minimatch@2.0.10` is being required by `webtask-runtime` because of `babel`.

`babel` is only being used in the compiler to transform webtask code.

https://github.com/auth0/webtask-runtime/blob/f524e9f48b38a0022ba3b010005b2e1b697288a5/lib/compiler.js#L54-L65

The `babel` project is [deprecated](https://www.npmjs.com/package/babel). In order to update `minimatch`, `babel` needs to be replaced with `babel-core`. In order to support the `loose` property, `babel-preset-env` has been added and the `transform` call has been modified slightly.

Test suite is still passing ✅

Here are the inputs that have been tested between the two implementations:
```
""
null
false
true
"var test = () => {console.log('Hello World');}"
"({foo}) => foo"
"(foo=1) => foo"
"`${test}23`"
"[a,b,...c] = [1,2,3,4,5];"
"var test = {...foo, ...bar};"
"var {a,b,c,...d} = {a:1, b:2, c:3, d:4};"
"var a = 1; var obj = {a};"
"class Rectangle {constructor(height, width) {this.height = height;this.width = width;}}"
"var test = 'dynamic'; var obj = {[test]:'yo'};"
"var f = (x, y, z) => { x + y + z; }; f(...[1,2,3]) == 6"
"let x = 1; if (x) { let y = 2; }"
"const x = 1;"
"for (var value of {1:1}) {}"
```

Running `npm ls minimatch` now returns:
```
webtask-runtime@1.7.1 /Users/sky/Desktop/Dev/Auth0/webtask-runtime
├─┬ babel-core@6.26.3
│ └── minimatch@3.0.4
└─┬ eslint@4.19.1
  ├─┬ glob@7.1.2
  │ └── minimatch@3.0.4  deduped
  └── minimatch@3.0.4  deduped
```